### PR TITLE
as to ensure that the git repository has Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: daily
+      time: "05:30"
+      timezone: Europe/London
+    pull-request-branch-name:
+      separator: "-"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+      time: "05:40"
+      timezone: Europe/London
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
and it's enabled for Docker images and the relevant package
ecosystem (e.g. Bundler)

ref.:
https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates